### PR TITLE
[WIP] l4 を LSTM に変更し，体験再生を時系列にして入力する

### DIFF
--- a/agent/cognitive/module.py
+++ b/agent/cognitive/module.py
@@ -99,7 +99,7 @@ class UBComponent(brica1.Component):
         super(UBComponent, self).__init__()
         self.use_gpu = use_gpu
         data_size = 10**5
-        replay_size = 32
+        replay_size = 32 # This variable is not constant, i.e. it is changed in every replay.
         hist_size = 1
         initial_exploration = 300#10**3
         dim = 10240

--- a/agent/cognitive/module.py
+++ b/agent/cognitive/module.py
@@ -101,7 +101,7 @@ class UBComponent(brica1.Component):
         data_size = 10**5
         replay_size = 32
         hist_size = 1
-        initial_exploration = 10**3
+        initial_exploration = 300#10**3
         dim = 10240
         self.experience = Experience(use_gpu=self.use_gpu, data_size=data_size, replay_size=replay_size,
                                      hist_size=hist_size, initial_exploration=initial_exploration, dim=dim)

--- a/agent/ml/experience.py
+++ b/agent/ml/experience.py
@@ -48,6 +48,7 @@ class Experience:
         tmp_episode_end_flags = self.d[4].T[0].copy()
         print('tmp_episode_end_flags = %s' % tmp_episode_end_flags)
         indices = [i for i in range(len(tmp_episode_end_flags)) if tmp_episode_end_flags[i]]
+        indices.insert(0, -1)
         print('indices = %s' % indices)
 
         tmp_rewards = self.d[2].T[0].copy()
@@ -55,21 +56,24 @@ class Experience:
 #        rewards = []
 #        for i in range(len(indices) - 2):
 #            rewards.append(reduce(lambda x, y: x + y, tmp_rewards[indices[i] + 1:indices[i + 1] + 1]))
-        each_sum_rewards = [reduce(lambda x, y: x + y, tmp_rewards[indices[i] + 1:indices[i + 1] + 1]) for i in range(len(indices) - 2)]
+        #each_sum_rewards = [reduce(lambda x, y: x + y, tmp_rewards[indices[i] + 1:indices[i + 1] + 1]) for i in range(len(indices) - 1)]
+        each_sum_rewards = [sum(tmp_rewards[indices[i] + 1:indices[i + 1] + 1]) for i in range(len(indices) - 1)]
         print('each_sum_rewards = %s' % each_sum_rewards)
         each_sum_rewards = utils.softmax(each_sum_rewards)
         print('softmaxed each_sum_rewards = %s' % each_sum_rewards)
 
         while True:
             #selected_end_index_of_indices = random.randint(1, len(indices) - 1)
-            selected_end_index_of_indices = np.random.choice(len(indices) - 2, p=each_sum_rewards) + 1
+            selected_end_index_of_indices = np.random.choice(len(indices) - 1, p=each_sum_rewards) + 1
             print('selected_end_index_of_indices = %s' % selected_end_index_of_indices)
-            if (indices[selected_end_index_of_indices] - self.replay_size + 1) - (indices[selected_end_index_of_indices - 1] + 1) >= 0:
+            self.replay_size = indices[selected_end_index_of_indices] - indices[selected_end_index_of_indices - 1]
+            if self.replay_size > 0:
                 print('broken')
                 break
 
-        selected_start_index = random.randint(indices[selected_end_index_of_indices - 1] + 1, indices[selected_end_index_of_indices] - self.replay_size + 1)
-        print('selected_start_index = %s' % selected_start_index)
+        #selected_start_index = random.randint(indices[selected_end_index_of_indices - 1] + 1, indices[selected_end_index_of_indices] - self.replay_size + 1)
+        selected_start_index = indices[selected_end_index_of_indices - 1] + 1
+        print('selected_start_index = %s, self.replay_size = %s' % (selected_start_index, self.replay_size,))
 
         a = np.array([range(selected_start_index, selected_start_index + self.replay_size)]).T
         print(a)

--- a/agent/ml/q_net.py
+++ b/agent/ml/q_net.py
@@ -15,7 +15,7 @@ class QNet:
     # Hyper-Parameters
     gamma = 0.99  # Discount factor
     initial_exploration = 10**3  # Initial exploratoin. original: 5x10^4
-    replay_size = 32  # Replay (batch) size
+    #replay_size = 32  # Replay (batch) size
     target_model_update_freq = 10**4  # Target update frequancy. original: 10^4
     data_size = 10**5  # Data size of history. original: 10^6
     hist_size = 1  # original: 4
@@ -67,6 +67,9 @@ class QNet:
 
     def forward(self, state, action, reward, state_dash, episode_end):
         #num_of_batch = state.shape[0]
+        replay_size = state.shape[0]
+        print('replay_size = %s' % replay_size)
+
         s = [Variable(one_state) for one_state in state]
         print('s = %s' % map(lambda x: x.data, s))
         s_dash = [Variable(one_state_dash) for one_state_dash in state_dash]
@@ -101,7 +104,7 @@ class QNet:
 
         #for i in xrange(num_of_batch):
         print('reward = %s' % reward)
-        for i in xrange(self.replay_size):
+        for i in xrange(replay_size):
             print('reward[%s] = %s' % (i, reward[i],))
             if not episode_end[i][0]:
                 tmp_ = reward[i] + self.gamma * max_q_dash[i]
@@ -126,7 +129,7 @@ class QNet:
         td_clip = [one_td * (abs(one_td.data) <= 1) + one_td/abs(one_td_tmp) * (abs(one_td.data) > 1) for one_td, one_td_tmp in zip(td, td_tmp)]
         print('td_clip = %s' % td_clip)
 
-        zero_val = np.zeros((self.replay_size, 1, self.num_of_actions), dtype=np.float32)
+        zero_val = np.zeros((replay_size, 1, self.num_of_actions), dtype=np.float32)
         if self.use_gpu >= 0:
             zero_val = cuda.to_gpu(zero_val)
         zero_val = Variable(zero_val)


### PR DESCRIPTION
とりあえず1つのエピソードが終わってから，各ステップで実際にアクションを求めるモデルを切り替えてます．  
  
従来はどうやら体験再生をバッチ処理にして使っていたようですが，現在はその配列をバッチではなく時系列データとして利用しています．

現在の明らかな問題は，誤差逆伝播に時間がかかりすぎて，実際のアクション算出にまで影響が出ていると思われること．